### PR TITLE
Better graph hover visuals

### DIFF
--- a/Playgrounds_Application/Simulators/Experimental/bondingSimulator.py
+++ b/Playgrounds_Application/Simulators/Experimental/bondingSimulator.py
@@ -65,32 +65,41 @@ def app():
     # plots
     stake_bond_chart = go.Figure()
 
-    stake_bond_chart.add_trace(go.Scatter(x=stake_bond_df.Epochs, y=stake_bond_df.Vested_Ohms, name='(4,4) Growth', fill=None, line=dict(color='#00aff3', width=2)))
-    stake_bond_chart.add_trace(go.Scatter(x=stake_bond_df.Epochs, y=stake_bond_df.Stake_Growth,name='(3,3) Growth', line=dict(color='#ff2a0a', width=2)))
+    stake_bond_chart.add_trace(go.Scatter(x=stake_bond_df.Epochs, y=stake_bond_df.Vested_Ohms, name='(4,4) Growth',
+                                          fill=None, line=dict(color='#00aff3', width=2)))
+    stake_bond_chart.add_trace(go.Scatter(x=stake_bond_df.Epochs, y=stake_bond_df.Stake_Growth, name='(3,3) Growth',
+                                          line=dict(color='#ff2a0a', width=2)))
 
-    stake_bond_chart.update_layout(autosize = True,showlegend=True, margin=dict(l=20, r=30, t=10, b=20))
-    stake_bond_chart.update_layout(legend=dict(yanchor="top", y=0.99, xanchor="left", x=0.01),xaxis_title = "Epochs (Vesting period)", yaxis_title = "Total Ohms")
-    stake_bond_chart.update_layout({'paper_bgcolor': 'rgba(0,0,0,0)', 'plot_bgcolor': 'rgba(0, 0, 0, 0)'})
+    stake_bond_chart.update_layout(autosize=True, showlegend=True, margin=dict(l=20, r=30, t=10, b=20))
+    stake_bond_chart.update_layout(legend=dict(yanchor="top", y=0.99, xanchor="left", x=0.01),
+                                   xaxis_title="Epochs (Vesting period)", yaxis_title = "Total Ohms")
+    stake_bond_chart.update_layout({'plot_bgcolor': 'rgba(0, 0, 0, 0)'})
 
-    stake_bond_chart.update_xaxes(showline=True, linewidth=0.1, linecolor='#31333F',showgrid=False, gridwidth=0.1,mirror=True)
-    stake_bond_chart.update_yaxes(showline=True, linewidth=0.1, linecolor='#31333F',showgrid=False, gridwidth=0.01,mirror=True)
+    stake_bond_chart.update_xaxes(showline=True, linewidth=0.1, linecolor='#31333F', showgrid=False, gridwidth=0.1, mirror=True)
+    stake_bond_chart.update_yaxes(showline=True, linewidth=0.1, linecolor='#31333F', showgrid=False, gridwidth=0.01, mirror=True)
 
+    bonding_hover_template = "<b>Epoch: </b> %{x} <br>"
+    bonding_hover_template += "<b>Ohm: </b> %{y} <br>"
+    stake_bond_chart.update_traces(hovertemplate=bonding_hover_template)
 
     #=============================
 
     stake_bond_ROIchart = go.Figure()
 
-    stake_bond_ROIchart.add_trace(go.Scatter(x=stake_bond_df.Epochs, y=stake_bond_df.Bond_ROI, name='(4,4) ROI  ',line=dict(color='#00aff3', width=2)))
-    stake_bond_ROIchart.add_trace(go.Scatter(x=stake_bond_df.Epochs, y=stake_bond_df.Stake_ROI,name='(3,3) ROI  ', fill=None,line=dict(color='#ff2a0a', width=2)))
+    stake_bond_ROIchart.add_trace(go.Scatter(x=stake_bond_df.Epochs, y=stake_bond_df.Bond_ROI, name='(4,4) ROI  ',
+                                             line=dict(color='#00aff3', width=2)))
+    stake_bond_ROIchart.add_trace(go.Scatter(x=stake_bond_df.Epochs, y=stake_bond_df.Stake_ROI, name='(3,3) ROI  ', fill=None,
+                                             line=dict(color='#ff2a0a', width=2)))
 
     stake_bond_ROIchart.update_layout(autosize = True,showlegend=True, margin=dict(l=20, r=30, t=10, b=20))
-    stake_bond_ROIchart.update_layout(legend=dict(yanchor="top", y=0.99, xanchor="left", x=0.01), xaxis_title = "Epochs (Vesting period)", yaxis_title = "ROI based on claim/stake frequency")
-    stake_bond_ROIchart.update_layout({'paper_bgcolor': 'rgba(0,0,0,0)', 'plot_bgcolor': 'rgba(0, 0, 0, 0)'})
+    stake_bond_ROIchart.update_layout(legend=dict(yanchor="top", y=0.99, xanchor="left", x=0.01),
+                                      xaxis_title = "Epochs (Vesting period)", yaxis_title = "ROI based on claim/stake frequency")
+    stake_bond_ROIchart.update_layout({'plot_bgcolor': 'rgba(0, 0, 0, 0)'})
 
-    stake_bond_ROIchart.update_xaxes(showline=True, linewidth=0.1, linecolor='#31333F',showgrid=False, gridwidth=0.1,mirror=True)
-    stake_bond_ROIchart.update_yaxes(showline=True, linewidth=0.1, linecolor='#31333F',showgrid=False, gridwidth=0.01,mirror=True)
+    stake_bond_ROIchart.update_xaxes(showline=True, linewidth=0.1, linecolor='#31333F', showgrid=False, gridwidth=0.1, mirror=True)
+    stake_bond_ROIchart.update_yaxes(showline=True, linewidth=0.1, linecolor='#31333F', showgrid=False, gridwidth=0.01, mirror=True)
 
-
+    stake_bond_ROIchart.update_traces(hovertemplate=bonding_hover_template)
 # end region
 
 

--- a/Playgrounds_Application/Simulators/Experimental/mainDashboard.py
+++ b/Playgrounds_Application/Simulators/Experimental/mainDashboard.py
@@ -123,17 +123,21 @@ def app():
 
     st.subheader('Metrics visualized')
     explorer_chart = px.line(selected_metric_df)
-    explorer_chart.update_layout(autosize=True, showlegend=True ,legend_title_text='Metrics',
+    explorer_chart.update_layout(autosize=True, showlegend=True, legend_title_text='Metrics',
                                  margin=dict(l=20, r=30, t=10, b=20))
-    explorer_chart.update_traces(mode="lines", hovertemplate=None)
-    explorer_chart.update_layout(legend=dict(yanchor="top",y=0.99,xanchor="left",x=0.01), hovermode='x unified',
+    explorer_chart.update_layout(legend=dict(yanchor="top", y=0.99, xanchor="left", x=0.01),
                                  hoverlabel_bgcolor="#04001f", hoverlabel_align='auto', hoverlabel_namelength=-1,
                                  hoverlabel_font_size=15)
-    explorer_chart.update_layout({'paper_bgcolor': 'rgba(0,0,0,0)', 'plot_bgcolor': 'rgba(0, 0, 0, 0)'})
-    explorer_chart.update_xaxes(title = 'Date',showline=True, linewidth=0.1, linecolor='#31333F',
-                                showgrid=False, gridwidth=0.1,mirror=True)
-    explorer_chart.update_yaxes(title = 'Metrics',showline=True, linewidth=0.1, linecolor='#31333F',
-                                showgrid=False, gridwidth=0.01,mirror=True)
+    explorer_chart.update_layout({'plot_bgcolor': 'rgba(0, 0, 0, 0)'})
+    explorer_chart.update_xaxes(title='Date', showline=True, linewidth=0.1, linecolor='#31333F',
+                                showgrid=False, gridwidth=0.1, mirror=True)
+    explorer_chart.update_yaxes(title='Metrics', showline=True, linewidth=0.1, linecolor='#31333F',
+                                showgrid=False, gridwidth=0.01, mirror=True)
+
+    explorer_hover_template = "<b>Value: </b> %{y} <br>"
+    explorer_hover_template += "<b>Date: </b> %{x} <br>"
+    explorer_chart.update_traces(hovertemplate=explorer_hover_template)
+
     st.plotly_chart(explorer_chart, use_container_width=True)
 
     st.subheader('Selected metrics in tabulated view')

--- a/Playgrounds_Application/Simulators/Experimental/stakingSimulator.py
+++ b/Playgrounds_Application/Simulators/Experimental/stakingSimulator.py
@@ -228,18 +228,30 @@ def app():
 
     ohmGrowthResult_df_Chart = go.Figure()
 
-    ohmGrowthResult_df_Chart.add_trace(go.Scatter(x=ohmGrowthResult_df.Days, y=ohmGrowthResult_df.Total_Ohms, name='(3,3) ROI  ', fill=None ))
-    ohmGrowthResult_df_Chart.add_trace(go.Scatter(x=ohmGrowthResult_df.Days, y=ohmGrowthResult_df.Profit_Adjusted_Total_Ohms, name='(3,3) Profit adjusted ROI  '))
-    ohmGrowthResult_df_Chart.add_trace(go.Scatter(x=ohmGrowthResult_df.Days, y=ohmGrowthResult_df.DCA_Adjusted_Total_Ohms,name='(3,3) DCA adjusted ROI  '))
-    ohmGrowthResult_df_Chart.add_trace(go.Scatter(x=ohmGrowthResult_df.Days, y=ohmGrowthResult_df.Min_OhmGrowth, name='Min Growth Rate  ', fill=None, ))
-    ohmGrowthResult_df_Chart.add_trace(go.Scatter(x=ohmGrowthResult_df.Days, y=ohmGrowthResult_df.Max_OhmGrowth, name='Max Growth Rate  ', fill=None, ))
+    ohmGrowthResult_df_Chart.add_trace(go.Scatter(x=ohmGrowthResult_df.Days,
+                                                  y=ohmGrowthResult_df.Total_Ohms, name='(3,3) ROI', fill=None))
+    ohmGrowthResult_df_Chart.add_trace(go.Scatter(x=ohmGrowthResult_df.Days,
+                                                  y=ohmGrowthResult_df.Profit_Adjusted_Total_Ohms,
+                                                  name='(3,3) Profit adjusted ROI  '))
+    ohmGrowthResult_df_Chart.add_trace(go.Scatter(x=ohmGrowthResult_df.Days,
+                                                  y=ohmGrowthResult_df.DCA_Adjusted_Total_Ohms, name='(3,3) DCA adjusted ROI  '))
+    ohmGrowthResult_df_Chart.add_trace(go.Scatter(x=ohmGrowthResult_df.Days,
+                                                  y=ohmGrowthResult_df.Min_OhmGrowth, name='Min Growth Rate  ', fill=None, ))
+    ohmGrowthResult_df_Chart.add_trace(go.Scatter(x=ohmGrowthResult_df.Days,
+                                                  y=ohmGrowthResult_df.Max_OhmGrowth, name='Max Growth Rate  ', fill=None, ))
 
     ohmGrowthResult_df_Chart.update_layout(autosize=True, showlegend=True, margin=dict(l=20, r=30, t=10, b=20))
     ohmGrowthResult_df_Chart.update_layout({'paper_bgcolor': 'rgba(0,0,0,0)', 'plot_bgcolor': 'rgba(0, 0, 0, 0)'})
-    ohmGrowthResult_df_Chart.update_layout(legend=dict(yanchor="top", y=0.99, xanchor="left", x=0.01), xaxis_title = "Days", yaxis_title = "Total Ohms")
+    ohmGrowthResult_df_Chart.update_layout(legend=dict(yanchor="top", y=0.99, xanchor="left", x=0.01), xaxis_title = "Days",
+                                           yaxis_title = "Total Ohms")
+    ohmGrowthResult_df_Chart.update_xaxes(showline=True, linewidth=0.1, linecolor='#31333F', showgrid=False, gridwidth=0.01,
+                                          mirror=True)
+    ohmGrowthResult_df_Chart.update_yaxes(showline=True, linewidth=0.1, linecolor='#31333F', showgrid=False, gridwidth=0.01,
+                                          mirror=True, zeroline=False)
 
-    ohmGrowthResult_df_Chart.update_xaxes(showline=True, linewidth=0.1, linecolor='#31333F', showgrid=False, gridwidth=0.01,mirror=True)
-    ohmGrowthResult_df_Chart.update_yaxes(showline=True, linewidth=0.1, linecolor='#31333F', showgrid=False, gridwidth=0.01,mirror=True, zeroline=False)
+    hovertemp = "<b>Day: </b> %{x} <br>"
+    hovertemp += "<b>Ohm: </b> %{y} <br>"
+    ohmGrowthResult_df_Chart.update_traces(hovertemplate=hovertemp)
 
     #st.title('Staking Playground')
     #st.write("-----------------------------")

--- a/Playgrounds_Application/Simulators/Experimental/stakingSimulator.py
+++ b/Playgrounds_Application/Simulators/Experimental/stakingSimulator.py
@@ -241,9 +241,9 @@ def app():
                                                   y=ohmGrowthResult_df.Max_OhmGrowth, name='Max Growth Rate  ', fill=None, ))
 
     ohmGrowthResult_df_Chart.update_layout(autosize=True, showlegend=True, margin=dict(l=20, r=30, t=10, b=20))
-    ohmGrowthResult_df_Chart.update_layout({'paper_bgcolor': 'rgba(0,0,0,0)', 'plot_bgcolor': 'rgba(0, 0, 0, 0)'})
-    ohmGrowthResult_df_Chart.update_layout(legend=dict(yanchor="top", y=0.99, xanchor="left", x=0.01), xaxis_title = "Days",
-                                           yaxis_title = "Total Ohms")
+    ohmGrowthResult_df_Chart.update_layout({'plot_bgcolor': 'rgba(0, 0, 0, 0)'})
+    ohmGrowthResult_df_Chart.update_layout(legend=dict(yanchor="top", y=0.99, xanchor="left", x=0.01), xaxis_title="Days",
+                                           yaxis_title="Total Ohms")
     ohmGrowthResult_df_Chart.update_xaxes(showline=True, linewidth=0.1, linecolor='#31333F', showgrid=False, gridwidth=0.01,
                                           mirror=True)
     ohmGrowthResult_df_Chart.update_yaxes(showline=True, linewidth=0.1, linecolor='#31333F', showgrid=False, gridwidth=0.01,


### PR DESCRIPTION
Closes #19 

This PR improves the hover data readability for all charts in this PG. 
After messing with this for **way too long** I've unlocked the best looking hover text I've been able to create so far.

<img width="828" alt="Screen Shot 2022-01-21 at 10 52 09 PM" src="https://user-images.githubusercontent.com/94268527/150623984-f08a9219-c614-418c-b0e5-63e782b0223f.png">
<img width="1146" alt="Screen Shot 2022-01-21 at 10 54 28 PM" src="https://user-images.githubusercontent.com/94268527/150623988-cf0966d4-e856-412b-a653-a824ddf0f0a1.png">
<img width="1134" alt="Screen Shot 2022-01-21 at 10 59 35 PM" src="https://user-images.githubusercontent.com/94268527/150623991-c0352968-c404-4fa0-98cd-24089e303493.png">

